### PR TITLE
Fix index.d.ts path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "module": "./dist/index.js",
   "type": "module",
-  "types": "./src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist/"
   ],


### PR DESCRIPTION
The PR solves a typescript error being raised in the module consuming this library.
